### PR TITLE
Hotfix/closing modal through ide url panel

### DIFF
--- a/packages/vscode-extension/lib/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router_helpers.js
@@ -1,0 +1,11 @@
+function onRequestRouteChange({ router, pathname, params }) {
+  // in order to close a modal (https://github.com/expo/expo/issues/26922#issuecomment-1996862878)
+  router.dismissAll();
+  setTimeout(() => {
+    router.push(pathname, params);
+  }, 0);
+}
+
+module.exports = {
+  onRequestRouteChange,
+};

--- a/packages/vscode-extension/lib/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router_helpers.js
@@ -1,9 +1,6 @@
 function onRequestRouteChange({ router, pathname, params }) {
-  // in order to close a modal (https://github.com/expo/expo/issues/26922#issuecomment-1996862878)
-  router.dismissAll();
-  setTimeout(() => {
-    router.push(pathname, params);
-  }, 0);
+  router.navigate(pathname);
+  router.setParams(params);
 }
 
 module.exports = {

--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -2,6 +2,7 @@ const { useSyncExternalStore } = require("react");
 const { useEffect } = require("react");
 const { useRouter } = require("expo-router");
 const { store } = require("expo-router/build/global-state/router-store");
+const { onRequestRouteChange } = require("./expo_router_helpers");
 
 function computeRouteIdentifier(pathname, params) {
   return pathname + JSON.stringify(params);
@@ -35,7 +36,7 @@ function useRouterPluginMainHook({ onNavigationChange }) {
       };
     },
     requestNavigationChange: ({ pathname, params }) => {
-      router.push(pathname, params);
+      onRequestRouteChange({ pathname, params, router });
     },
   };
 }

--- a/packages/vscode-extension/lib/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v2_plugin.js
@@ -2,6 +2,7 @@ const { useSyncExternalStore } = require("react");
 const { useEffect } = require("react");
 const { useRouter } = require("expo-router");
 const { store } = require("expo-router/src/global-state/router-store");
+const { onRequestRouteChange } = require("./expo_router_helpers");
 
 function computeRouteIdentifier(pathname, params) {
   return pathname + JSON.stringify(params);
@@ -35,7 +36,7 @@ function useRouterPluginMainHook({ onNavigationChange }) {
       };
     },
     requestNavigationChange: ({ pathname, params }) => {
-      router.push(pathname, params);
+      onRequestRouteChange({ pathname, params, router });
     },
   };
 }


### PR DESCRIPTION
# The problem: 
Currently, navigating to another page is impossible if a modal is opened. The root cause of the problem is using `router.push` that does not dismiss modals. You can read more about it.
https://github.com/expo/expo/issues/26922#issuecomment-1996862878
 
https://github.com/software-mansion/react-native-ide/assets/77052270/5b26f4cb-24cf-4c13-a57d-f33f9a20d680

By replacing the current implementation with `navigate` and `setParams ` we can eliminate the problem.

https://github.com/software-mansion/react-native-ide/assets/77052270/ff425ade-8f77-4144-bf42-18368870ee86






